### PR TITLE
Added runImmediately param

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To start a timer, you have to dispatch an action with type `START_TIMER` with a 
 * name (required) - `String` representing the name of the timer.
 * action (required) - `String` matching an action type **or** a `Function` that you would like to periodically execute.
 * interval (required) - Timer interval in milliseconds
+* runImmediately (optional) - `Boolean` to determine whether to fire the action immediately. This is set to `true` by default.
 
 #### Using `action` as an action type
 
@@ -35,7 +36,8 @@ export const startTimer = () => ({
   payload: {
     name: 'exampleTimer',
     action: 'SOME_ACTION_TICK',
-    interval: 1000
+    interval: 1000,
+    runImmediately: true
   }
 });
 ```
@@ -59,7 +61,8 @@ export const exampleAction = () => async dispatch => {
           // do something with this error
         }
       },
-      interval: 5000
+      interval: 5000,
+      runImmediately: false
     }
   });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,12 @@ const validateTimerInterval = (interval) => {
   }
 };
 
-const startTimer = ({ dispatch }, { name, action, interval }) => {
+const startTimer = (
+  { dispatch },
+  {
+    name, action, interval, runImmediately = true,
+  },
+) => {
   validateTimerName(name);
   validateTimerAction(action);
   validateTimerInterval(interval);
@@ -43,7 +48,7 @@ const startTimer = ({ dispatch }, { name, action, interval }) => {
     typeof action === 'string' ? () => dispatch({ type: action }) : action;
 
   // run immediately
-  func();
+  if (runImmediately) func();
 
   // create the setInterval
   timers[name] = setInterval(func, interval);


### PR DESCRIPTION
Added `runImmediately` param to determine whether to fire the action immediately. This is set to `true` by default. 

https://github.com/elselabs/redux-timer/issues/2 